### PR TITLE
sf::View zoom method replacement with Box2D-SFML unit scaling method to fix potential graphical artifacts bugs

### DIFF
--- a/code/Utility/Box2dDebugDraw.cpp
+++ b/code/Utility/Box2dDebugDraw.cpp
@@ -53,9 +53,9 @@ void Box2dDebugDraw::DrawSolidPolygon(const b2Vec2 *vertices, int32 vertexCount,
 
 void Box2dDebugDraw::DrawCircle(const b2Vec2 &center, float radius, const b2Color &color)
 {
-	sf::CircleShape circle(radius * PPM);
-	circle.setOrigin(radius, radius);
-	circle.setPosition(center.x, center.y);
+	sf::CircleShape circle(toPixels(radius));
+	circle.setOrigin(toPixels(radius, radius));
+	circle.setPosition(toPixels(center));
 	circle.setFillColor(sf::Color::Transparent);
 	circle.setOutlineThickness(-1.f);
 	circle.setOutlineColor(b2ColorToSfColor(color));
@@ -68,9 +68,9 @@ void Box2dDebugDraw::DrawSolidCircle(const b2Vec2 &center, float radius, const b
 	b2Color fillColor = color;
 	fillColor.a = 0.5f;
 
-	sf::CircleShape circle(radius * PPM);
-	circle.setOrigin(radius, radius);
-	circle.setPosition(center.x, center.y);
+	sf::CircleShape circle(toPixels(radius));
+	circle.setOrigin(toPixels(radius, radius));
+	circle.setPosition(toPixels(center));
 	circle.setFillColor(b2ColorToSfColor(fillColor));
 	circle.setOutlineThickness(-1.f);
 	circle.setOutlineColor(b2ColorToSfColor(color));
@@ -96,7 +96,7 @@ void Box2dDebugDraw::DrawTransform(const b2Transform &xf)
 	float lineLength = 0.4f;
 
 	b2Vec2 xAxis = xf.p + lineLength * xf.q.GetXAxis();
-	
+
 	std::array<sf::Vertex, 2> redLine =
 	{
 		{

--- a/code/Utility/Box2dDebugDraw.cpp
+++ b/code/Utility/Box2dDebugDraw.cpp
@@ -1,6 +1,7 @@
 #include "Utility/Box2dDebugDraw.hpp"
 #include "Utility/ColorConverter.hpp"
 #include "Utility/VectorConverter.hpp"
+#include "World/UnitScaling.hpp"
 
 #include <SFML/Graphics/ConvexShape.hpp>
 #include <SFML/Graphics/PrimitiveType.hpp>
@@ -19,7 +20,7 @@ void Box2dDebugDraw::DrawPolygon(const b2Vec2* vertices, int32 vertexCount, cons
 
 	for (int32 i = 0; i < vertexCount; ++i)
 	{
-		sf::Vector2f vertex = b2Vec2ToSfVec(vertices[i]);
+		sf::Vector2f vertex = toPixels(vertices[i]);
 		polygon.setPoint(i, vertex);
 	}
 
@@ -36,7 +37,7 @@ void Box2dDebugDraw::DrawSolidPolygon(const b2Vec2 *vertices, int32 vertexCount,
 
 	for (int32 i = 0; i < vertexCount; ++i)
 	{
-		sf::Vector2f vertex = b2Vec2ToSfVec(vertices[i]);
+		sf::Vector2f vertex = toPixels(vertices[i]);
 		polygon.setPoint(i, vertex);
 	}
 
@@ -52,7 +53,7 @@ void Box2dDebugDraw::DrawSolidPolygon(const b2Vec2 *vertices, int32 vertexCount,
 
 void Box2dDebugDraw::DrawCircle(const b2Vec2 &center, float radius, const b2Color &color)
 {
-	sf::CircleShape circle(radius);
+	sf::CircleShape circle(radius * PPM);
 	circle.setOrigin(radius, radius);
 	circle.setPosition(center.x, center.y);
 	circle.setFillColor(sf::Color::Transparent);
@@ -67,7 +68,7 @@ void Box2dDebugDraw::DrawSolidCircle(const b2Vec2 &center, float radius, const b
 	b2Color fillColor = color;
 	fillColor.a = 0.5f;
 
-	sf::CircleShape circle(radius);
+	sf::CircleShape circle(radius * PPM);
 	circle.setOrigin(radius, radius);
 	circle.setPosition(center.x, center.y);
 	circle.setFillColor(b2ColorToSfColor(fillColor));
@@ -82,8 +83,8 @@ void Box2dDebugDraw::DrawSegment(const b2Vec2 &p1, const b2Vec2 &p2, const b2Col
 	std::array<sf::Vertex, 2> line =
 	{
 		{
-			{{p1.x, p1.y}, b2ColorToSfColor(color)},
-			{{p2.x, p2.y}, b2ColorToSfColor(color)}
+			{{toPixels(p1)}, b2ColorToSfColor(color)},
+			{{toPixels(p2)}, b2ColorToSfColor(color)}
 		}
 	};
 
@@ -99,8 +100,8 @@ void Box2dDebugDraw::DrawTransform(const b2Transform &xf)
 	std::array<sf::Vertex, 2> redLine =
 	{
 		{
-			{b2Vec2ToSfVec(xf.p), sf::Color::Red},
-			{b2Vec2ToSfVec(xAxis), sf::Color::Red}
+			{toPixels(xf.p), sf::Color::Red},
+			{toPixels(xAxis), sf::Color::Red}
 		}
 	};
 
@@ -109,8 +110,8 @@ void Box2dDebugDraw::DrawTransform(const b2Transform &xf)
 	std::array<sf::Vertex, 2> greenLine =
 	{
 		{
-			{b2Vec2ToSfVec(xf.p), sf::Color::Green},
-			{b2Vec2ToSfVec(yAxis), sf::Color::Green}
+			{toPixels(xf.p), sf::Color::Green},
+			{toPixels(yAxis), sf::Color::Green}
 		}
 	};
 
@@ -120,7 +121,7 @@ void Box2dDebugDraw::DrawTransform(const b2Transform &xf)
 
 void Box2dDebugDraw::DrawPoint(const b2Vec2 &p, float size, const b2Color &color)
 {
-	sf::Vertex point(b2Vec2ToSfVec(p), b2ColorToSfColor(color));
+	sf::Vertex point(toPixels(p), b2ColorToSfColor(color));
 
 	m_window.draw(&point, 1, sf::Points);
 }

--- a/code/World/Components/RigidBodyComponent.cpp
+++ b/code/World/Components/RigidBodyComponent.cpp
@@ -1,0 +1,96 @@
+#include "World/Components/RigidBodyComponent.hpp"
+#include "World/UnitScaling.hpp"
+
+#include "Utility/VectorConverter.hpp"
+
+#include <box2d/box2d.h>
+
+namespace astro
+{
+	void RigidBodyComponent::setTransform(const sf::Vector2f& position, float angle)
+	{
+		body->SetTransform(toMeters(position), angle);
+	}
+
+	b2Transform RigidBodyComponent::getTransform() const
+	{
+		const auto& transform = body->GetTransform();
+
+		return {sfVec2ToB2Vec(toPixels(transform.p)), transform.q};
+	}
+
+	sf::Vector2f RigidBodyComponent::getPosition() const
+	{
+		return toPixels(body->GetPosition());
+	}
+
+	sf::Vector2f RigidBodyComponent::getWorldCenter() const
+	{
+		return toPixels(body->GetWorldCenter());
+	}
+
+	sf::Vector2f RigidBodyComponent::getLocalCenter() const
+	{
+		return toPixels(body->GetLocalCenter());
+	}
+
+	void RigidBodyComponent::setLinearVelocity(const sf::Vector2f& velocity)
+	{
+		body->SetLinearVelocity(toMeters(velocity));
+	}
+
+	sf::Vector2f RigidBodyComponent::getLinearVelocity() const
+	{
+		return toPixels(body->GetLinearVelocity());
+	}
+
+	void RigidBodyComponent::applyForce(const sf::Vector2f& force, const sf::Vector2f& point, bool wake)
+	{
+		body->ApplyForce(toMeters(force), toMeters(point), wake);
+	}
+
+	void RigidBodyComponent::applyForceToCenter(const sf::Vector2f& force, bool wake)
+	{
+		body->ApplyForceToCenter(toMeters(force), wake);
+	}
+
+	void RigidBodyComponent::applyLinearImpulse(const sf::Vector2f& impulse, const sf::Vector2f& point, bool wake)
+	{
+		body->ApplyLinearImpulse(toMeters(impulse), toMeters(point), wake);
+	}
+
+	void RigidBodyComponent::applyLinearImpulseToCenter(const sf::Vector2f& impulse, bool wake)
+	{
+		body->ApplyLinearImpulseToCenter(toMeters(impulse), wake);
+	}
+
+	sf::Vector2f RigidBodyComponent::getWorldPoint(const sf::Vector2f& localPoint) const
+	{
+		return toPixels(body->GetWorldPoint(toMeters(localPoint)));
+	}
+
+	sf::Vector2f RigidBodyComponent::getWorldVector(const sf::Vector2f& localVector) const
+	{
+		return toPixels(body->GetWorldVector(toMeters(localVector)));
+	}
+
+	sf::Vector2f RigidBodyComponent::getLocalPoint(const sf::Vector2f& worldPoint) const
+	{
+		return toPixels(body->GetLocalPoint(toMeters(worldPoint)));
+	}
+
+	sf::Vector2f RigidBodyComponent::getLocalVector(const sf::Vector2f& worldVector) const
+	{
+		return toPixels(body->GetLocalVector(toMeters(worldVector)));
+	}
+
+	sf::Vector2f RigidBodyComponent::getLinearVelocityFromWorldPoint(const sf::Vector2f& worldPoint) const
+	{
+		return toPixels(body->GetLinearVelocityFromWorldPoint(toMeters(worldPoint)));
+	}
+
+	sf::Vector2f RigidBodyComponent::getLinearVelocityFromLocalPoint(const sf::Vector2f& localPoint) const
+	{
+		return toPixels(body->GetLinearVelocityFromLocalPoint(toMeters(localPoint)));
+	}
+}

--- a/code/World/EntityFactory.cpp
+++ b/code/World/EntityFactory.cpp
@@ -24,9 +24,9 @@ entt::entity spawnShip(entt::registry& registry, const sf::Vector2f& position, b
 	static std::array<sf::Vertex, 3> shipMesh
 	{
 		{
-			{{0.f * PPM, -0.5f * PPM}, sf::Color::White},
-			{{-0.5f * PPM, 0.5f * PPM}, sf::Color::White},
-			{{0.5f * PPM, 0.5f * PPM}, sf::Color::White}
+			{{toPixels(0.f, -0.5f)}, sf::Color::White},
+			{{toPixels(-0.5f, 0.5f)}, sf::Color::White},
+			{{toPixels(0.5f, 0.5f)}, sf::Color::White}
 		}
 	};
 

--- a/code/World/EntityFactory.cpp
+++ b/code/World/EntityFactory.cpp
@@ -55,13 +55,13 @@ entt::entity spawnAsteroid(entt::registry& registry, const sf::Vector2f& positio
 		vertices[x * 3 + 2] = {{b2Vec2ToSfVec(asteroidTriangles[x][2])}, sf::Color::White};
 	}
 
-	registry.emplace<RigidBodyComponent>(entity, createAsteroidBody(physicsWorld, sfVec2ToB2Vec(position), asteroidTriangles));
-
 	toPixels(vertices.data(), vertices.size());
 
 	auto& mesh = registry.emplace<OwningMeshComponent>(entity);
 	mesh.type = sf::Triangles;
 	mesh.vertices.swap(vertices);
+
+	registry.emplace<RigidBodyComponent>(entity, createAsteroidBody(physicsWorld, sfVec2ToB2Vec(position), asteroidTriangles));
 
 	return entity;
 }

--- a/code/World/EntityFactory.cpp
+++ b/code/World/EntityFactory.cpp
@@ -55,13 +55,13 @@ entt::entity spawnAsteroid(entt::registry& registry, const sf::Vector2f& positio
 		vertices[x * 3 + 2] = {{b2Vec2ToSfVec(asteroidTriangles[x][2])}, sf::Color::White};
 	}
 
+	registry.emplace<RigidBodyComponent>(entity, createAsteroidBody(physicsWorld, sfVec2ToB2Vec(position), asteroidTriangles));
+
 	toPixels(vertices.data(), vertices.size());
 
 	auto& mesh = registry.emplace<OwningMeshComponent>(entity);
 	mesh.type = sf::Triangles;
 	mesh.vertices.swap(vertices);
-
-	registry.emplace<RigidBodyComponent>(entity, createAsteroidBody(physicsWorld, sfVec2ToB2Vec(position), asteroidTriangles));
 
 	return entity;
 }

--- a/code/World/EntityFactory.cpp
+++ b/code/World/EntityFactory.cpp
@@ -5,6 +5,7 @@
 #include "World/Components/Components.hpp"
 #include "World/Components/RigidBodyComponent.hpp"
 #include "World/PhysicsBodyFactory.hpp"
+#include "World/UnitScaling.hpp"
 
 #include <SFML/Graphics/PrimitiveType.hpp>
 #include <SFML/Graphics/Vertex.hpp>
@@ -23,9 +24,9 @@ entt::entity spawnShip(entt::registry& registry, const sf::Vector2f& position, b
 	static std::array<sf::Vertex, 3> shipMesh
 	{
 		{
-			{{0.f, -0.5f}, sf::Color::White},
-			{{-0.5f, 0.5f}, sf::Color::White},
-			{{0.5f, 0.5f}, sf::Color::White}
+			{{0.f * PPM, -0.5f * PPM}, sf::Color::White},
+			{{-0.5f * PPM, 0.5f * PPM}, sf::Color::White},
+			{{0.5f * PPM, 0.5f * PPM}, sf::Color::White}
 		}
 	};
 
@@ -53,6 +54,8 @@ entt::entity spawnAsteroid(entt::registry& registry, const sf::Vector2f& positio
 		vertices[x * 3 + 1] = {{b2Vec2ToSfVec(asteroidTriangles[x][1])}, sf::Color::White};
 		vertices[x * 3 + 2] = {{b2Vec2ToSfVec(asteroidTriangles[x][2])}, sf::Color::White};
 	}
+
+	toPixels(vertices.data(), vertices.size());
 
 	auto& mesh = registry.emplace<OwningMeshComponent>(entity);
 	mesh.type = sf::Triangles;

--- a/code/World/Scripts/ShipScript.cpp
+++ b/code/World/Scripts/ShipScript.cpp
@@ -2,6 +2,7 @@
 
 #include "Utility/Keyboard.hpp"
 #include "Utility/VectorConverter.hpp"
+#include "World/UnitScaling.hpp"
 #include "World/Components/RigidBodyComponent.hpp"
 #include "World/CoordinateSpaceMapper.hpp"
 
@@ -93,8 +94,7 @@ void ShipScript::onEvent(sf::Event event)
 		{
 			const auto x = event.mouseMove.x;
 			const auto y = event.mouseMove.y;
-			const sf::Vector2f mousePosition = m_coordinateMapper->mapToViewSpace({x, y});
-			m_pointToLookAt = sfVec2ToB2Vec(mousePosition);
+			m_pointToLookAt = toMeters(m_coordinateMapper->mapToViewSpace({x, y}));
 			break;
 		}
 		default:

--- a/code/World/Systems.cpp
+++ b/code/World/Systems.cpp
@@ -18,12 +18,12 @@ void drawEntities(const entt::registry& registry, sf::RenderTarget& target)
 
 	for (const auto& entity : view)
 	{
-		const b2Body* const body = registry.get<RigidBodyComponent>(entity).body;
+		const auto& rbc = registry.get<RigidBodyComponent>(entity);
 
 		sf::Transform transform;
-		transform.translate(b2Vec2ToSfVec(body->GetPosition()));
-		transform.rotate(thor::toDegree(body->GetAngle()));
-		
+		transform.translate(rbc.getPosition());
+		transform.rotate(thor::toDegree(rbc.body->GetAngle()));
+
 		if (registry.all_of<MeshComponent>(entity))
 		{
 			const MeshComponent mesh = registry.get<MeshComponent>(entity);

--- a/code/World/UnitScaling.cpp
+++ b/code/World/UnitScaling.cpp
@@ -1,0 +1,42 @@
+#include "World/UnitScaling.hpp"
+
+#include "Utility/VectorConverter.hpp"
+
+#include <box2d/b2_math.h>
+#include <SFML/System/Vector2.hpp>
+#include <SFML/Graphics/Vertex.hpp>
+
+namespace astro
+{
+	b2Vec2 toMeters(const sf::Vector2f& pixels)
+	{
+		const b2Vec2 inMeters {pixels.x / astro::PPM, pixels.y / astro::PPM};
+
+		return inMeters;
+	}
+
+	sf::Vector2f toPixels(const b2Vec2& meters)
+	{
+		const sf::Vector2f inPixels {meters.x * astro::PPM, meters.y * astro::PPM};
+
+		return inPixels;
+	}
+
+	void toMeters(sf::Vertex *vertices, std::size_t size)
+	{
+		for (std::size_t x = 0; x < size; ++x)
+		{
+			auto& vertex = *(vertices + x);
+			vertex.position = b2Vec2ToSfVec(toMeters(vertex.position));
+		}
+	}
+
+	void toPixels(sf::Vertex *vertices, std::size_t size)
+	{
+		for (std::size_t x = 0; x < size; ++x)
+		{
+			auto& vertex = *(vertices + x);
+			vertex.position = toPixels(sfVec2ToB2Vec(vertex.position));
+		}
+	}
+}

--- a/code/World/UnitScaling.cpp
+++ b/code/World/UnitScaling.cpp
@@ -8,18 +8,44 @@
 
 namespace astro
 {
+	constexpr float PPM = 48.f;
+
 	b2Vec2 toMeters(const sf::Vector2f& pixels)
 	{
-		const b2Vec2 inMeters {pixels.x / astro::PPM, pixels.y / astro::PPM};
+		const b2Vec2 inMeters {pixels.x / PPM, pixels.y / PPM};
 
 		return inMeters;
 	}
 
 	sf::Vector2f toPixels(const b2Vec2& meters)
 	{
-		const sf::Vector2f inPixels {meters.x * astro::PPM, meters.y * astro::PPM};
+		const sf::Vector2f inPixels {meters.x * PPM, meters.y * PPM};
 
 		return inPixels;
+	}
+
+	b2Vec2 toMeters(float x, float y)
+	{
+		const b2Vec2 inMeters {x / PPM, y / PPM};
+
+		return inMeters;
+	}
+
+	sf::Vector2f toPixels(float x, float y)
+	{
+		const sf::Vector2f inPixels {x * PPM, y * PPM};
+
+		return inPixels;
+	}
+
+	float toMeters(float pixels)
+	{
+		return pixels / PPM;
+	}
+
+	float toPixels(float meters)
+	{
+		return meters * PPM;
 	}
 
 	void toMeters(sf::Vertex *vertices, std::size_t size)

--- a/code/World/World.cpp
+++ b/code/World/World.cpp
@@ -1,6 +1,7 @@
 #include "World/World.hpp"
 
 #include "Asteroid/PolygonsGenerator.hpp"
+#include "Utility/Box2dDebugDraw.hpp"
 #include "World/Entity.hpp"
 #include "World/EntityFactory.hpp"
 #include "World/Systems.hpp"
@@ -39,12 +40,14 @@ namespace astro
 
 World::World(sf::RenderTarget& mainWindow)
 	: m_physicsWorld({0,0})
-	, m_worldView({0.f, 0.f}, {12, 12})
+	, m_worldView(mainWindow.getDefaultView())
 	, m_mainWindow(mainWindow)
 	, m_worldSpaceMapper(mainWindow, m_worldView)
 	, m_box2dDebugDraw(mainWindow)
 {
 	m_physicsWorld.SetDebugDraw(&m_box2dDebugDraw);
+
+	m_worldView.setCenter(0,0);
 
 	m_registry.on_destroy<NativeScriptComponent>().connect<&World::deallocateNscInstance>();
 	m_registry.on_destroy<RigidBodyComponent>().connect<&World::deallocateB2BodyInstance>();

--- a/header/World/Components/RigidBodyComponent.hpp
+++ b/header/World/Components/RigidBodyComponent.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <SFML/System/Vector2.hpp>
+
 class b2Body;
+class b2Transform;
 
 namespace astro
 {
@@ -8,6 +11,32 @@ namespace astro
 struct RigidBodyComponent
 {
 	b2Body* body;
+
+	void setTransform(const sf::Vector2f& position, float angle);
+	b2Transform getTransform() const;
+
+	sf::Vector2f getPosition() const;
+
+	sf::Vector2f getWorldCenter() const;
+	sf::Vector2f getLocalCenter() const;
+
+	void setLinearVelocity(const sf::Vector2f& velocity);
+	sf::Vector2f getLinearVelocity() const;
+
+	void applyForce(const sf::Vector2f& force, const sf::Vector2f& point, bool wake);
+	void applyForceToCenter(const sf::Vector2f& force, bool wake);
+
+	void applyLinearImpulse(const sf::Vector2f& impulse, const sf::Vector2f& point, bool wake);
+	void applyLinearImpulseToCenter(const sf::Vector2f& impulse, bool wake);
+
+	sf::Vector2f getWorldPoint(const sf::Vector2f& localPoint) const;
+	sf::Vector2f getWorldVector(const sf::Vector2f& localVector) const;
+
+	sf::Vector2f getLocalPoint(const sf::Vector2f& worldPoint) const;
+	sf::Vector2f getLocalVector(const sf::Vector2f& worldVector) const;
+
+	sf::Vector2f getLinearVelocityFromWorldPoint(const sf::Vector2f& worldPoint) const;
+	sf::Vector2f getLinearVelocityFromLocalPoint(const sf::Vector2f& localPoint) const;
 };
 
 } // namespace astro

--- a/header/World/UnitScaling.hpp
+++ b/header/World/UnitScaling.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstddef>
+
+class b2Vec2;
+namespace sf
+{ 
+	class Vertex;
+
+	template<typename T> class Vector2;
+	typedef Vector2<float> Vector2f;
+}
+
+namespace astro
+{
+	inline constexpr float PPM = 64.f;
+
+	b2Vec2 toMeters(const sf::Vector2f& pixels);
+	sf::Vector2f toPixels(const b2Vec2& meters);
+
+	void toMeters(sf::Vertex* vertices, std::size_t size);
+	void toPixels(sf::Vertex* vertices, std::size_t size);
+}

--- a/header/World/UnitScaling.hpp
+++ b/header/World/UnitScaling.hpp
@@ -13,10 +13,14 @@ namespace sf
 
 namespace astro
 {
-	inline constexpr float PPM = 64.f;
-
 	b2Vec2 toMeters(const sf::Vector2f& pixels);
 	sf::Vector2f toPixels(const b2Vec2& meters);
+
+	b2Vec2 toMeters(float x, float y);
+	sf::Vector2f toPixels(float x, float y);
+
+	float toMeters(float pixels);
+	float toPixels(float meters);
 
 	void toMeters(sf::Vertex* vertices, std::size_t size);
 	void toPixels(sf::Vertex* vertices, std::size_t size);


### PR DESCRIPTION
This pull request aims to fix potential graphical artifacts bugs caused by zooming to a very small space with sf::View to view small graphical bodies using some Box2D-SFML unit scaling methods to scale physical units to renderer units -- using `48.f` as the conversion multiplier.